### PR TITLE
Gatsby v2: Change navigateTo to navigate

### DIFF
--- a/src/components/Contact/Contact.js
+++ b/src/components/Contact/Contact.js
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars: 0 */
 
-import { navigateTo } from "gatsby-link";
+import { navigate } from "gatsby";
 import Button from "antd/lib/button";
 import Form from "antd/lib/form";
 import Input from "antd/lib/input";
@@ -41,7 +41,7 @@ const Contact = props => {
     })
       .then(() => {
         console.log("Form submission success");
-        navigateTo("/success");
+        navigate("/success");
       })
       .catch(error => {
         console.error("Form submission error:", error);


### PR DESCRIPTION
The `navigateTo` method in gatsby-link was renamed to `navigate` to mirror the API used by @reach/router.

In addition to the name change, `gatsby-link` is now directly exported from the `gatsby` package and can’t be installed directly.