### PR TITLE
Gatsby v2: Update gatsby-ssr.js

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,4 +1,4 @@
-import flush from "styled-jsx/server";
+const flush = require("styled-jsx/server");
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   if (process.env.NODE_ENV === `production`) {


### PR DESCRIPTION
During build it threw an error telling this file is using mixed module systems so I changed it.

Convert to either pure CommonJS or pure ES6
Gatsby v2 uses webpack 4 which is stricter about modules with mixed module systems.

All ES6 is 👍:

// GOOD: ES modules syntax works
```
import foo from "foo"
export default foo
```
All CommonJS is 👌:

// GOOD: CommonJS syntax works
```
const foo = require("foo")
module.exports = foo
```
Mixing requires and export is 🙀:

// BAD: Mixed ES and CommonJS module syntax will cause failures
```
const foo = require("foo")
export default foo
```
Mixing import and module.exports 🤪:

// BAD: Mixed ES and CommonJS module syntax will cause failures
```
import foo from "foo"
module.exports = foo
```