### PR TITLE
Gatsby v2: Import Link from Gatsby

### DIFF
--- a/src/components/Post/NextPrev.js
+++ b/src/components/Post/NextPrev.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Link from "gatsby-link";
+import { Link } from "gatsby";
 
 import FaArrowRight from "react-icons/lib/fa/arrow-right";
 import FaArrowLeft from "react-icons/lib/fa/arrow-left";


### PR DESCRIPTION
All components and utility functions from `gatsby-link` are now exported from `gatsby` package. Therefore you should import it directly from `gatsby`.