### PR TITLE
Gatsby v2: Import Link from Gatsby

### DIFF
--- a/src/components/Post/Meta.js
+++ b/src/components/Post/Meta.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Link from "gatsby-link";
+import { Link } from "gatsby";
 
 import FaCalendar from "react-icons/lib/fa/calendar";
 import FaUser from "react-icons/lib/fa/user";


### PR DESCRIPTION
All components and utility functions from `gatsby-link` are now exported from `gatsby` package. Therefore you should import it directly from `gatsby`.