### PR TITLE
Gatsby v2: Import Link from Gatsby

### DIFF
--- a/src/components/Search/Hit.js
+++ b/src/components/Search/Hit.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Link from "gatsby-link";
+import { Link } from "gatsby";
 
 const Hit = props => {
   const { hit } = props;


### PR DESCRIPTION
All components and utility functions from `gatsby-link` are now exported from `gatsby` package. Therefore you should import it directly from `gatsby`.