### PR TITLE
Gatsby v2: Import Link from Gatsby

### DIFF
--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Link from "gatsby-link";
+import { Link } from "gatsby";
 
 const List = props => {
   const { edges, theme } = props;


### PR DESCRIPTION
All components and utility functions from `gatsby-link` are now exported from `gatsby` package. Therefore you should import it directly from `gatsby`.