### PR TITLE
Gatsby v2: Import Link from Gatsby

### DIFF
--- a/src/components/Menu/Item.js
+++ b/src/components/Menu/Item.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Link from "gatsby-link";
+import { Link } from "gatsby";
 
 const Item = props => {
   const { theme, item: { label, to, icon: Icon } = {}, onClick } = props;


### PR DESCRIPTION
All components and utility functions from `gatsby-link` are now exported from `gatsby` package. Therefore you should import it directly from `gatsby`.