### PR TITLE
Gatsby v2: Import graphql from Gatsby

### DIFF
--- a/src/pages/category.js
+++ b/src/pages/category.js
@@ -1,7 +1,7 @@
 import FaTag from "react-icons/lib/fa/tag";
 import PropTypes from "prop-types";
 import React from "react";
-
+import { graphql } from "gatsby";
 import { ThemeContext } from "../layouts";
 import Article from "../components/Article/";
 import Headline from "../components/Article/Headline";

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-
+import { graphql } from "gatsby";
 import { ThemeContext } from "../layouts";
 import Article from "../components/Article";
 import Contact from "../components/Contact";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-
+import { graphql } from "gatsby";
 import { ThemeContext } from "../layouts";
 import Blog from "../components/Blog";
 import Hero from "../components/Hero";

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-
+import { graphql } from "gatsby";
 require("core-js/fn/array/find");
 
 import Article from "../components/Article";

--- a/src/templates/CategoryTemplate.js
+++ b/src/templates/CategoryTemplate.js
@@ -1,7 +1,7 @@
 import FaTag from "react-icons/lib/fa/tag";
 import PropTypes from "prop-types";
 import React from "react";
-
+import { graphql } from "gatsby";
 import Seo from "../components/Seo";
 import { ThemeContext } from "../layouts";
 import Article from "../components/Article";

--- a/src/templates/PageTemplate.js
+++ b/src/templates/PageTemplate.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-
+import { graphql } from "gatsby";
 import Seo from "../components/Seo";
 import Article from "../components/Article";
 import Page from "../components/Page";

--- a/src/templates/PostTemplate.js
+++ b/src/templates/PostTemplate.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-
+import { graphql } from "gatsby";
 require("prismjs/themes/prism-okaidia.css");
 
 import Seo from "../components/Seo";


### PR DESCRIPTION
The `graphql` tag function that Gatsby v1 auto-supports is deprecated in v2. Gatsby will throw deprecation warning unless you explicitly import it from the `gatsby` package.
