### PR TITLE
Gatsby v2: Rename pathContext to pageContext

### DIFF
--- a/src/templates/CategoryTemplate.js
+++ b/src/templates/CategoryTemplate.js
@@ -10,7 +10,7 @@ import List from "../components/List";
 
 const CategoryTemplate = props => {
   const {
-    pathContext: { category },
+    pageContext: { category },
     data: {
       allMarkdownRemark: { totalCount, edges },
       site: {
@@ -49,7 +49,7 @@ const CategoryTemplate = props => {
 
 CategoryTemplate.propTypes = {
   data: PropTypes.object.isRequired,
-  pathContext: PropTypes.object.isRequired
+  pageContext: PropTypes.object.isRequired
 };
 
 export default CategoryTemplate;

--- a/src/templates/PostTemplate.js
+++ b/src/templates/PostTemplate.js
@@ -17,7 +17,7 @@ const PostTemplate = props => {
         siteMetadata: { facebook }
       }
     },
-    pathContext: { next, prev }
+    pageContext: { next, prev }
   } = props;
 
   return (
@@ -44,7 +44,7 @@ const PostTemplate = props => {
 
 PostTemplate.propTypes = {
   data: PropTypes.object.isRequired,
-  pathContext: PropTypes.object.isRequired
+  pageContext: PropTypes.object.isRequired
 };
 
 export default PostTemplate;


### PR DESCRIPTION
Rename `pathContext` to `pageContext`
Now `pathContext` is deprecated in favor of `pageContext`.