### PR TITLE
Automating the creation of the post directory

### DIFF
--- a/newPost.js
+++ b/newPost.js
@@ -1,0 +1,21 @@
+const fs = require('fs')
+const date = new Date; 
+const year = date.getFullYear();
+const month = date.getMonth() + 1; 
+const day = date.getDate();
+const name =process.argv[2]
+
+const newPost = `${year}-${month}-${day}--${name}`
+
+fs.mkdirSync(`content/posts/${newPost}`)
+
+let stream = fs.createWriteStream(`content/posts/${newPost}/index.md`);
+
+stream.once('open', function(fd) {
+  stream.write("---\n");
+  stream.write("title:''\n");
+  stream.write("cover:''\n");
+  stream.write("author:''\n");
+  stream.write("---\n");
+  stream.end();
+});

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "lint-errors": "eslint src/**/*.{js,jsx} --quiet",
     "lint": "eslint src/**/*.{js,jsx}",
     "stylelint": "stylelint src/**/*.js",
-    "generate-app-icons": "sh ./scripts/generate-app-icons.sh"
+    "generate-app-icons": "sh ./scripts/generate-app-icons.sh",
+    "post":"node newPost.js"
   },
   "devDependencies": {
     "@mapbox/stylelint-processor-arbitrary-tags": "^0.2.0",


### PR DESCRIPTION
I plan to write my posts via PRs, every time I need to add a post, I need to create a post directory, index.md etc. I thought it would be a good idea to automate this to a certain extent.  What do you think ?

**New Command:** 
`npm run post [post-tile]`

**Example usage:** 
`npm run post the-latest-and-greatest`

this creates a directory inside posts named `2018-11-18--the-latest-and-greatest` with an index.md file inside of it containing: 

```
---
title:''
cover:''
author:''
---

```


